### PR TITLE
Updated setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Clone a copy of the contact-congress and store it somewhere:
 
 Then cd back over to congress-forms and run
 
- - `bundle exec rake congress-forms:map_forms[contact_congress_directory]`
+ - `bundle exec rake congress-forms:update_git[contact_congress_directory]`
 
 replacing `contact_congress_directory` with the path where you cloned the `contact-congress` project.
 


### PR DESCRIPTION
The current setup instructions expect a rake task called map_forms, which no longer exists. Setup instructions edited to reference the update_git rake task instead.